### PR TITLE
Fix backreference in a character class

### DIFF
--- a/autostatic.py
+++ b/autostatic.py
@@ -27,7 +27,7 @@ CUSTOM_STATIC_REF_PATTERN_KEY = "AUTOSTATIC_REFERENCE_PATTERN"
 USE_PELICAN_LIKE_REF_KEY = "AUTOSTATIC_USE_PELICANLIKE_REF"
 
 # Works everywhere
-DEFAULT_STATIC_REF_PATTERN = r"""{static(?:\s+|\|)((?:"|')?)(?P<path>[^\1=]+?)\1(?:(?:\s+|\|)(?P<extra>.*))?\s*}"""
+DEFAULT_STATIC_REF_PATTERN = r"""{static(?:\s+|\|)((?:"|')?)(?P<path>[^(?P=1)=]+?)\1(?:(?:\s+|\|)(?P<extra>.*))?\s*}"""
 
 # Works just in url-value attributes
 PELICAN_LIKE_REF_TAG = r"""{static(?:(?:\s+|\|)(?P<extra>.*))?}"""


### PR DESCRIPTION
The `re` module doc states that "Inside the '[' and ']' of a character class, all numeric escapes are treated as characters" (instead of group matches). This causes `[^\1=] to be considered as "not the character \001 nor =" instead of "not the characters matched in the first group nor =", which in turns causes an error when trying to include a file with spaces with`{static "/files/2014/my file.pdf"}`:

```
WARNING: Cannot get modification stamp for /path/to/blog/content/&quot;/files/2014/my
  |     [Errno 2] No such file or directory: '/path/to/blog/content/&quot;/files/2014/my'
CRITICAL: [Errno 2] No such file or directory: '/path/to/blog/content/&quot;/files/2014/my'
```

This can be avoided by using the `(?P=name)` form.

(Only tested on Python 3.4.2 with Pelican 3.5.0).
