### PR TITLE
Fix HTMLParser import for python 2/3 compatibility.

### DIFF
--- a/autostatic.py
+++ b/autostatic.py
@@ -9,10 +9,11 @@ import re
 import shutil
 
 # For html escaping/unescaping
-import HTMLParser
 try:
+    import html.parser as HTMLParser
     from html import escape as html_escape  # py3
 except ImportError:
+    import HTMLParser
     from cgi import escape as html_escape # py2
 
 import six


### PR DESCRIPTION
Hi,

Your plugin is nice.

There is a problem with the plugin around the import of HTMLParser.  

After a quick debugging session, I have had the following debug code around the import of HTMLParser (in python 3.7 virtual environment).

```
import traceback
try:
    import HTMLParser
except Exception as e:
    traceback.print_exc()
```

I have the following exception during the pelican generation.

```
Traceback (most recent call last):
  File "/home/rix/pelican-plugins/pelican-autostatic/autostatic.py", line 14, in <module>
    import HTMLParser
  File "/home/rix/pelican_env/lib/python3.7/site-packages/HTMLParser.py", line 11, in <module>
    import markupbase
ModuleNotFoundError: No module named 'markupbase'
```
I propose the following fix which work well in python 3.

```
# For html escaping/unescaping
try:
    import html.parser as HTMLParser
    from html import escape as html_escape  # py3
except ImportError:
    import HTMLParser
    from cgi import escape as html_escape # py2
```

You can refer to this stackoverflow post for more information.

`https://stackoverflow.com/questions/34630669/python-importerror-no-module-named-htmlparser`


By